### PR TITLE
Added conda recipe

### DIFF
--- a/buildscripts/condarecipe/bld.bat
+++ b/buildscripts/condarecipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/buildscripts/condarecipe/build.sh
+++ b/buildscripts/condarecipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: jplephem
+  version: "2.1"
+
+source:
+  fn: jplephem-2.1.tar.gz
+  url: https://pypi.python.org/packages/source/j/jplephem/jplephem-2.1.tar.gz
+  md5: d20989d5ea2fea493805a9d11ec02aae
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - python
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - jplephem
+
+about:
+  home: https://pypi.python.org/pypi/jplephem
+  license: MIT License
+  summary: 'Python version of NASA DE4xx ephemerides, the basis for the 
+Astronomical Alamanac'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/buildscripts/condarecipe/run_test.sh
+++ b/buildscripts/condarecipe/run_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Retrieve necessary files
+wget http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de421.bsp
+wget http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp
+wget ftp://ssd.jpl.nasa.gov/pub/eph/planets/test-data/430/testpo.430
+
+# Perform tests
+python -m unittest discover jplephem.test
+
+python -m jplephem.jpltest


### PR DESCRIPTION
I used `conda skeleton` to create a conda recipe for python-jplephem so it is directly installable with conda. At the build step, the necessary files are downloaded and the tests are run. I think there is a way to tell TravisCI to build the recipes and upload them to Binstar when doing a release but I have to investigate further.