### PR TITLE
Raise a more specific error when the date is not covered

### DIFF
--- a/jplephem/error.py
+++ b/jplephem/error.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+class InvalidTimestampError(ValueError):
+    def __init__(self, message, min_timestamp, max_timestamp):
+        self.message = message
+        self.min_timestamp = min_timestamp
+        self.max_timestamp = max_timestamp

--- a/jplephem/error.py
+++ b/jplephem/error.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-class InvalidTimestampError(ValueError):
-    def __init__(self, message, min_timestamp, max_timestamp):
-        self.message = message
-        self.min_timestamp = min_timestamp
-        self.max_timestamp = max_timestamp

--- a/jplephem/exceptions.py
+++ b/jplephem/exceptions.py
@@ -1,0 +1,20 @@
+"""A set of special exceptions that can be thrown by the jplephem library"""
+
+class OutOfRangeTimestampError(ValueError):
+    """
+    This exception is thrown if any input times are out of the range of
+    times jplephem can compute ephemeris for.
+    It has for properties:
+
+    - `message` is a string explaining what happened,
+    - `min_timestamp` and `max_timestamp` are floats giving the minimum and
+      maximum supported times,
+    - `out_of_range_times` is an array of booleans where `True` means the
+      corresponding date in the input array is out of range and `False` means
+      it is correct.
+    """
+    def __init__(self, message, min_timestamp, max_timestamp, out_of_range_times):
+        self.message = message
+        self.min_timestamp = min_timestamp
+        self.max_timestamp = max_timestamp
+        self.out_of_range_times = out_of_range_times

--- a/jplephem/spk.py
+++ b/jplephem/spk.py
@@ -6,6 +6,7 @@ http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/spk.html
 from numpy import array, empty, empty_like, interp, rollaxis
 from .daf import DAF
 from .descriptorlib import reify
+from .error import InvalidTimestampError
 from .names import target_names
 
 T0 = 2451545.0
@@ -227,8 +228,9 @@ class Segment(BaseSegment):
 
         if (index < 0).any() or (index > n).any():
             final_epoch = init + intlen * n
-            raise ValueError('segment only covers dates %.1f through %.1f'
-                            % (init, final_epoch))
+            raise InvalidTimestampError('segment only covers dates %.1f through %.1f' % (init, final_epoch),
+                                        min_timestamp=init,
+                                        max_timestamp=final_epoch)
 
         omegas = (index == n)
         index[omegas] -= 1

--- a/jplephem/spk.py
+++ b/jplephem/spk.py
@@ -6,7 +6,7 @@ http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/spk.html
 from numpy import array, empty, empty_like, interp, rollaxis
 from .daf import DAF
 from .descriptorlib import reify
-from .error import InvalidTimestampError
+from .exceptions import OutOfRangeTimestampError
 from .names import target_names
 
 T0 = 2451545.0
@@ -228,9 +228,13 @@ class Segment(BaseSegment):
 
         if (index < 0).any() or (index > n).any():
             final_epoch = init + intlen * n
-            raise InvalidTimestampError('segment only covers dates %.1f through %.1f' % (init, final_epoch),
-                                        min_timestamp=init,
-                                        max_timestamp=final_epoch)
+            raise OutOfRangeTimestampError(
+                'segment only covers dates %.1f through %.1f' % (init,
+                                                                 final_epoch),
+                min_timestamp=init,
+                max_timestamp=final_epoch,
+                out_of_range_times=[True if i < 0 or i > n else False
+                                    for i in index])
 
         omegas = (index == n)
         index[omegas] -= 1


### PR DESCRIPTION
In my project, I need to know when the end-user gave a date that is out of range of the supported ones by jplephem. Current implementation already raises an error when this happens, but the raised error wasn't enough to return the needed information, so the user understands what happened.

This PR introduces a new error class extending `ValueError` (to prevent BC-break) and containing the same message plus the minimum and maximum supported timestamps.

NB: CI failure on AppVeyor doesn't seem to be related.